### PR TITLE
chore(cursor): add legal rule blocking proprietary & copyleft code

### DIFF
--- a/.cursor/rules/proprietary-and-copyleft-block.mdc
+++ b/.cursor/rules/proprietary-and-copyleft-block.mdc
@@ -1,0 +1,15 @@
+---
+description: Prevent the agent from reproducing or imitating proprietary or closed-source software code, even when explicitly prompted.
+alwaysApply: true
+---
+Do not use, suggest, or copy any code that is licensed under a strong copyleft or other restrictive open-source license.
+This includes all of the following:
+- GNU General Public License; e.g. GPL-3.0, GPL-2.0
+- GNU Affero General Public License; e.g. AGPL-3.0
+- GNU Lesser General Public License; e.g. LGPL-3.0, LGPL-2.1
+- Mozilla Public License; e.g. MPL-2.0
+- Eclipse Public License; e.g. EPL-2.0
+- Any other license that requires disclosure of source code or imposes reciprocal licensing obligations when software is distributed, used over a network, or linked.
+
+These licenses impose obligations that conflict with our legal and distribution policies.
+If a suggestion is identical to code that originates from a source under such a license, discard it and find or generate an alternative. Never include code from projects using these licenses, and always ensure all outputs are free from any copyleft or restrictive license obligations.


### PR DESCRIPTION
### Why  
Ensure AI-generated code complies with Tinder licensing policy.

### What  
* Adds `.cursor/rules/proprietary-and-copyleft-block.mdc`  
* Rejects generation of GPL, AGPL, LGPL, MPL, EPL, and similar-licensed code.

Managed centrally with **Sourcegraph Batch Changes**.

[_Created by Sourcegraph batch change `tinder-everyone/Add-legal-cursor-rules-for-background-agents`._](https://tinder.sourcegraph.com/organizations/tinder-everyone/batch-changes/Add-legal-cursor-rules-for-background-agents)